### PR TITLE
Use (L)MDB backend instead of HDB

### DIFF
--- a/volatildap/server.py
+++ b/volatildap/server.py
@@ -144,8 +144,8 @@ class LdapServer(core.BaseServer):
             yield quote('TLSCertificateFile %s', self._tls_certificate_path)
             yield quote('TLSCertificateKeyFile %s', self._tls_key_path)
 
-        yield quote('moduleload back_hdb')
-        yield quote('database hdb')
+        yield quote('moduleload back_mdb')
+        yield quote('database mdb')
         yield quote('directory %s', self._datadir)
         yield quote('suffix %s', self.suffix)
         yield quote('rootdn %s', self.rootdn)


### PR DESCRIPTION
OpenLDAP 2.5.x has deprecated and removed support for the HDB backend,
which makes the tests fail.  This commit changes the backend to MDB,
which is the recommended one now.